### PR TITLE
Don't include the input files in the repository

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /target
 .idea
 Cargo.lock
+input/*.txt


### PR DESCRIPTION
As per the [Advent of Code's about page](https://adventofcode.com/2024/about), input files should not be publicly included in users' repositories (see #1 for more details).